### PR TITLE
Add description about missing main window after launch on Wayland

### DIFF
--- a/docs/en/manual/wayland.md
+++ b/docs/en/manual/wayland.md
@@ -45,6 +45,10 @@ No, thanks.
 
 The Gnome desktop does not support tray icons by nature. Ubuntu has made an [extension](https://extensions.gnome.org/extension/1301/ubuntu-appindicators/) to support a Gnome tray extension based on DBus communication. The result of testing so far is that the extension will display trays from Qv2ray running on Wayland under Arch Linux, but may not display them under the custom Ubuntu Wayland session. This is an upstream issue and cannot be addressed by this project.
 
+### Where is the application window?
+
+As described above, GNOME does not support tray icons, so does Wayland's reference compositor `weston`. With current version, the application main window will be hidden after launch if ___Auto Connect___ is enabled.(see [#1080](https://github.com/Qv2ray/Qv2ray/issues/1080) [#1097](https://github.com/Qv2ray/Qv2ray/issues/1080)). A current workaround is to launch Qv2ray again, then the main window will be activated and become visible.
+
 ## Clipboard
 
 Since Wayland does not have a unified clipboard interface, it may not be possible to use the right-click menu to copy and paste between applications running in Wayland. As a workaround, you can use `Ctrl + C/V` to copy and paste. Also note that when copying and pasting, open both the copy source window and the paste target window at the same time.

--- a/docs/en/manual/wayland.md
+++ b/docs/en/manual/wayland.md
@@ -16,7 +16,9 @@ If everything is in place, you can now try to run Qv2ray with the Wayland displa
 
 Qt5 programs in a Gnome environment run on Xwayland by default using the Xorg protocol (Xorg's fallback mode under Wayland). Therefore, to get Qv2ray to run under the Wayland display protocol you need to run the following command.
 
-``bash QT_QPA_PLATFORM=wayland qv2ray``
+```bash
+env QT_QPA_PLATFORM=wayland qv2ray
+```
 
 It works as follows.
 [! [Qv2ray On Wayland in Gnome Session](https://s1.ax1x.com/2020/11/07/BIuwb4.png)](https://imgchr.com/i/BIuwb4)

--- a/docs/en/manual/wayland.md
+++ b/docs/en/manual/wayland.md
@@ -16,9 +16,7 @@ If everything is in place, you can now try to run Qv2ray with the Wayland displa
 
 Qt5 programs in a Gnome environment run on Xwayland by default using the Xorg protocol (Xorg's fallback mode under Wayland). Therefore, to get Qv2ray to run under the Wayland display protocol you need to run the following command.
 
-``bash
-QT_QPA_PLATFORM=wayland qv2ray
-```
+``bash QT_QPA_PLATFORM=wayland qv2ray``
 
 It works as follows.
 [! [Qv2ray On Wayland in Gnome Session](https://s1.ax1x.com/2020/11/07/BIuwb4.png)](https://imgchr.com/i/BIuwb4)

--- a/docs/manual/wayland.md
+++ b/docs/manual/wayland.md
@@ -17,7 +17,7 @@ Qv2ray 是原生的 Qt5/C++ 程序，，能够完整地支持 Wayland 显示协�
 Gnome 环境下的 Qt5 程序默认使用 Xorg 协议运行于 Xwayland 上（Xorg 在 Wayland 下的后备模式）。因此，如果要让 Qv2ray 运行在 Wayland 显示协议下你需要运行如下命令：
 
 ```bash
-QT_QPA_PLATFORM=wayland qv2ray
+env QT_QPA_PLATFORM=wayland qv2ray
 ```
 
 运行效果如下：

--- a/docs/manual/wayland.md
+++ b/docs/manual/wayland.md
@@ -47,6 +47,10 @@ QT_QPA_PLATFORM=wayland qv2ray
 
 Gnome 桌面本就不支持托盘图标。Ubuntu 做了个[扩展](https://extensions.gnome.org/extension/1301/ubuntu-appindicators/)来支持了一个基于 DBus 通讯的 Gnome 托盘扩展。目前测试的结果是此扩展能在 Arch Linux 下显示运行于 Wayland 的 Qv2ray 的托盘，但是在 Ubuntu 定制的 Ubuntu Wayland 会话下可能无法显示。此为上游的问题，本项目无法处理。
 
+### 程序运行了却没有窗口
+
+如上所述, Gnome本不支持托盘图标, Wayland的官方compositor `Weston`也是如此. 在目前, 如果启用了Qv2ray的自动连接功能, 在程序执行后不会显示主视窗而是隐藏于托盘图标 (see [#1080](https://github.com/Qv2ray/Qv2ray/issues/1080) [#1097](https://github.com/Qv2ray/Qv2ray/issues/1080)) 目前只可以通过再次执行Qv2ray来激活被隐藏的窗口.
+
 ## 剪贴板
 
 由于 Wayland 没有统一的剪贴板接口，在运行于 Wayland 的应用之间可能无法使用右键菜单来复制粘贴。作为一个缓解措施，你可以使用 `Ctrl + C/V` 来进行复制粘贴。同时要注意，复制粘贴的时候要同时打开复制源窗口与粘贴目标窗口。

--- a/docs/manual/wayland.md
+++ b/docs/manual/wayland.md
@@ -49,7 +49,7 @@ Gnome 桌面本就不支持托盘图标。Ubuntu 做了个[扩展](https://exten
 
 ### 程序运行了却没有窗口
 
-如上所述, Gnome本不支持托盘图标, Wayland的官方compositor `Weston`也是如此. 在目前, 如果启用了Qv2ray的自动连接功能, 在程序执行后不会显示主视窗而是隐藏于托盘图标 (see [#1080](https://github.com/Qv2ray/Qv2ray/issues/1080) [#1097](https://github.com/Qv2ray/Qv2ray/issues/1080)) 目前只可以通过再次执行Qv2ray来激活被隐藏的窗口.
+如上所述, Gnome 本不支持托盘图标, Wayland 的官方 compositor `Weston` 也是如此. 在目前, 如果启用了 Qv2ray 的自动连接功能, 在程序执行后不会显示主视窗而是隐藏于托盘图标 (see [#1080](https://github.com/Qv2ray/Qv2ray/issues/1080) [#1097](https://github.com/Qv2ray/Qv2ray/issues/1080)) 目前只可以通过再次执行 Qv2ray 来激活被隐藏的窗口.
 
 ## 剪贴板
 


### PR DESCRIPTION
## Note
Also fixed a syntax error in English version of modified pages.