### PR TITLE
Fix: Environment variable names for build info

### DIFF
--- a/docs/hacking/cmake-argument.md
+++ b/docs/hacking/cmake-argument.md
@@ -27,7 +27,7 @@ title: CMake Argument Reference
 ## `QV2RAY_BUILD_INFO` / `QV2RAY_BUILD_EXTRA_INFO`
 - Default: `Qv2ray from manual build` and the ***Version Number***
 - Description: These strings will be displayed in "About" dialog of Qv2ray.
-- Note: You may also want to use the environment variables with the same names.
+- Note: You may also want to use the environment variables `_QV2RAY_BUILD_INFO_` and `_QV2RAY_BUILD_EXTRA_INFO_`.
 
 ## `QV2RAY_HAS_BUILTIN_THEMES`
 - Default: `ON`

--- a/docs/lang/zh/hacking/cmake-argument.md
+++ b/docs/lang/zh/hacking/cmake-argument.md
@@ -33,7 +33,7 @@ title: CMake 参数参考
 
 - 默认： `Qv2ray from manual build` 和 ***版本号***
 - 说明：这些字符串将在 Qv2ray的“关于”对话框中显示。
-- 注意：您可能也想使用具有相同名称的环境变量。
+- 注意：您也可以使用环境变量 `_QV2RAY_BUILD_INFO_` 和 `_QV2RAY_BUILD_EXTRA_INFO_`。
 
 ## `QV2RAY_HAS_BUILTIN_THEMES`
 


### PR DESCRIPTION
环境变量 `QV2RAY_BUILD_INFO` / `QV2RAY_BUILD_EXTRA_INFO` 貌似不起作用，正确的环境变量名也许是 `_QV2RAY_BUILD_INFO_` and `_QV2RAY_BUILD_EXTRA_INFO_`。

The environment variables with the same names (`QV2RAY_BUILD_INFO` / `QV2RAY_BUILD_EXTRA_INFO`) do not seem to work, and valid environment variable names may be `_QV2RAY_BUILD_INFO_` and `_QV2RAY_BUILD_EXTRA_INFO_`.